### PR TITLE
Fix: Unable to authenticate WAXLRS using "Basic" authentication method.

### DIFF
--- a/tincanlaunch/locallib.php
+++ b/tincanlaunch/locallib.php
@@ -99,7 +99,7 @@ function tincanlaunch_get_launch_url($registrationuuid) {
 	    ), 
 	    '', 
 	    '&'//,'PHP_QUERY_RFC3986'
-	)."&auth=". rawurlencode("Basic ".$basicauth); 
+	)."&auth=". rawurlencode("Basic%20".$basicauth); 
 	
 	return $rtnString;
 }


### PR DESCRIPTION
It seems that it was needed to replace the space character in "Basic " with "Basic%20" for the lunch url to work with WAXLRS.

Not sure if this implementation is according to the spec? (did not read it) Or it is a WAXLRS bug. Anyways, now it works :-)

BTW, I saw other LRSes (Rustici's public LRS) that do not use "Basic " and just send the base64_encode("username:password"). Weird :-)
