### PR TITLE
Mask password field in launch form

### DIFF
--- a/tincanlaunch/mod_form.php
+++ b/tincanlaunch/mod_form.php
@@ -94,7 +94,7 @@ class mod_tincanlaunch_mod_form extends moodleform_mod {
         $mform->addHelpButton('tincanlaunchlrslogin', 'tincanlaunchlrslogin', 'tincanlaunch');
 		
 		//Add basic authorisation pass. TODO: OAuth
-		$mform->addElement('text', 'tincanlaunchlrspass', get_string('tincanlaunchlrspass', 'tincanlaunch'), array('size'=>'64'));
+		$mform->addElement('passwordunmask', 'tincanlaunchlrspass', get_string('tincanlaunchlrspass', 'tincanlaunch'), array('size'=>'64'));
 		$mform->setType('tincanlaunchlrspass', PARAM_TEXT);
 		$mform->addRule('tincanlaunchlrspass', null, 'required', null, 'client');
         $mform->addRule('tincanlaunchlrspass', get_string('maximumchars', '', 255), 'maxlength', 255, 'client');


### PR DESCRIPTION
I have used "passwordunmask" because I thought it would be nice to enable the user to see his/her password. But, for better security you might just use "password".

What do you think?
