### PR TITLE
fix to trim quotes out of etags

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -547,7 +547,7 @@ function tincanlaunch_extract_etag($wrapperdata){
 	$etag ='';
 	foreach ($wrapperdata as $rtnHeader) {
 		if (strpos($rtnHeader, 'ETag') === 0){
-			$etag =substr($rtnHeader, 6);
+            $etag = trim(substr($rtnHeader, 6), '""');
 			return $etag;
 		}
 	}


### PR DESCRIPTION
In the end, it's necessary to remove the extra quotes around the etag for the plugin to work with LearningLocker. Luckily the fix still works with ScormCloud.
