### PR TITLE
Read ActivityID from tincan.xml using launchurl

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -553,3 +553,22 @@ function tincanlaunch_extract_etag($wrapperdata){
 	}
 }
 
+function tincanlaunch_getactivityid($lancuurl) {
+    // ""Only one activity definition within a package may contain launch or resource elements"
+    // Above quote, from : https://github.com/RusticiSoftware/launch/blob/master/lms_lrs.md
+    // todo: store $xml on a new field inside the activity's database table, to be used for grading and user's progress discerning
+    $xml = simplexml_load_file(dirname($lancuurl)."/tincan.xml");
+
+    if ($xml) {
+        // Check if that activity has a "launch" element
+        foreach($xml->activities->activity as $activity) {
+            if (isset($activity->launch)) {
+                return (string)$activity['id'][0];
+            }
+        }
+    }
+
+    return; // use first activity id if none found ? (string)$xml->activities->activity[0]['id'][0];
+
+}
+

--- a/mod_form.php
+++ b/mod_form.php
@@ -29,6 +29,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 require_once($CFG->dirroot.'/course/moodleform_mod.php');
+require_once(dirname(__FILE__).'/locallib.php');
 
 /**
  * Module instance settings form
@@ -71,11 +72,13 @@ class mod_tincanlaunch_mod_form extends moodleform_mod {
         $mform->addRule('tincanlaunchurl', get_string('maximumchars', '', 255), 'maxlength', 255, 'client');
         $mform->addHelpButton('tincanlaunchurl', 'tincanlaunchurl', 'tincanlaunch');
 		
-		$mform->addElement('text', 'tincanactivityid', get_string('tincanactivityid', 'tincanlaunch'), array('size'=>'64'));
-		$mform->setType('tincanactivityid', PARAM_TEXT);
-		$mform->addRule('tincanactivityid', null, 'required', null, 'client');
-        $mform->addRule('tincanactivityid', get_string('maximumchars', '', 255), 'maxlength', 255, 'client');
-        $mform->addHelpButton('tincanactivityid', 'tincanactivityid', 'tincanlaunch');
+		//$mform->addElement('text', 'tincanactivityid', get_string('tincanactivityid', 'tincanlaunch'), array('size'=>'64'));
+		//$mform->setType('tincanactivityid', PARAM_TEXT);
+		//$mform->addRule('tincanactivityid', null, 'required', null, 'client');
+        //$mform->addRule('tincanactivityid', get_string('maximumchars', '', 255), 'maxlength', 255, 'client');
+        //$mform->addHelpButton('tincanactivityid', 'tincanactivityid', 'tincanlaunch');
+        $mform->addElement('hidden', 'tincanactivityid', get_string('tincanactivityid', 'tincanlaunch'), array('size'=>'64'));
+        $mform->setType('tincanactivityid', PARAM_TEXT);
 
 		$mform->addElement('text', 'tincanlaunchlrsduration', get_string('tincanlaunchlrsduration', 'tincanlaunch'), array('size'=>'64'));
 		$mform->setType('tincanlaunchlrsduration', PARAM_TEXT);
@@ -178,6 +181,20 @@ class mod_tincanlaunch_mod_form extends moodleform_mod {
         if (empty($default_values['tincanverbid'])) {
             $default_values['completionverbenabled']=1;
         }
+    }
+
+    function validation($data, $files) {
+        $errors = parent::validation($data, $files);
+
+        // Get activity id from tincan.xml under root folder of activity's launch url.
+        $tincanactivityid = tincanlaunch_getactivityid($data['tincanlaunchurl']);
+        if (empty($tincanactivityid)) {
+            $errors['tincanlaunchurl'] = get_string('notincanactivityid', 'tincanlaunch');
+        } else {
+            // Update tincanactivityid in case it is valid.
+            $this->_form->_submitValues['tincanactivityid'] = $tincanactivityid;
+        }
+        return $errors;
     }
 	
 }


### PR DESCRIPTION
This is an experiment.
Feedback please :-)

The feature is based on the idea that their must be a tincan.xml file inside the root older of the activity and that one of its activities has a "launch" property with the launch file.

I have visually removed the activityid form field and turned it to hidden.
User can either input full activity URI (including launch file) or just a URL for an internet folder there the activity is available in its uncompressed form.
After submitting the form, the module validate that it can find a valid activityid on an activity that has a "launch" property from the list of activities inside the tincan.xml file that resides on the root folder of the launchurl. Otherwise, it returns error and the user is ask to input a proper/valid launch url.

Some ideas...
- Save tincan.xml raw data inside a new "xml" field on the the mdl_tincanlaunch table, so it will help later on to discern activity name from activity ids, when displaying grades and progress (verbs) on the "Grades and Progress" new feature page I am developing (on a separate issue)
- What we do when no ActivityID is found in the xml file, for various weird reasons?
