### PR TITLE
issues/20 fixes an issue with learninglocker when saving agent profiles

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -362,11 +362,11 @@ function tincanlaunch_get_global_parameters_and_save_agentprofile($data, $key){
 	$EtagHeader = "";
 	if (strlen(tincanlaunch_extract_etag($GetRequestReturnObj["metadata"]["wrapper_data"]))<1)
 	{
-		$EtagHeader = "If-None-Match : *";
+		$EtagHeader = "If-None-Match: *";
 	}
 	else
 	{	
-		$EtagHeader = "If-Match : ".tincanlaunch_extract_etag($GetRequestReturnObj["metadata"]["wrapper_data"]);
+		$EtagHeader = "If-Match: ".tincanlaunch_extract_etag($GetRequestReturnObj["metadata"]["wrapper_data"]);
 	}
 	
 	return tincanlaunch_save_agentprofile($data, $tincanlaunchsettings['tincanlaunchlrsendpoint'], $tincanlaunchsettings['tincanlaunchlrslogin'], $tincanlaunchsettings['tincanlaunchlrspass'], $tincanlaunchsettings['tincanlaunchlrsversion'], tincanlaunch_getactor(), $key, $EtagHeader);


### PR DESCRIPTION
Hi @garemoko - Although #20 has already been closed, I have been testing out the module with a local install of the latest LearningLocker code, and had trouble when _re-launching_ my TinCan content. 

LearningLocker refused to parse the If-Match/If-None-Match headers due to a trailing space in the field name, but the amendment in this PR corrects this issue, although this might be something that needs to be addressed in the LearningLocker codebase.
