### PR TITLE
StatementResult->getMore() sometimes returns an empty string

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -660,7 +660,7 @@ function tincanlaunch_get_statements($url, $basicLogin, $basicPass, $version, $a
 
     $allTheStatements = $statementsResponse->content->getStatements();
     $moreStatementsURL = $statementsResponse->content->getMore();
-    while (!is_null($moreStatementsURL)) {
+    while (!empty($moreStatementsURL)) {
         $moreStmtsResponse = $lrs->moreStatements($moreStatementsURL);
         if ($moreStmtsResponse->success == false) {
             return $moreStmtsResponse;


### PR DESCRIPTION
Learning Locker (and possibly other LRS) returns JSON that includes a
“more” element which may be an empty string. The !is_null() check returns
true which means the module attempts to fetch more statements when there
are none to fetch. Simply checking for !empty() gets around the problem.
