### PR TITLE
Sanitized registrationid value.

### DIFF
--- a/launch.php
+++ b/launch.php
@@ -34,7 +34,7 @@ $event->add_record_snapshot('tincanlaunch', $tincanlaunch);
 $event->trigger();
 
 // Get the registration id.
-$registrationid = $_GET["launchform_registration"];
+$registrationid = required_param('launchform_registration', PARAM_TEXT);
 if (empty($registrationid)) {
     echo "<div class='alert alert-error'>".get_string('tincanlaunch_regidempty', 'tincanlaunch')."</div>";
     // Failed to connect to LRS.


### PR DESCRIPTION
Clear input for any value from $_GET, $_POST or $_REQUEST per
https://docs.moodle.org/dev/Security#Don.27t_trust_any_input_from_users