### PR TITLE
Add support for remote launch url

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -510,8 +510,14 @@ function tincanlaunch_process_new_package($tincanlaunch) {
         // Skip if not. (The Moodle admin will need to enter the url manually).
         foreach ($manifest[0]["children"][0]["children"][0]["children"] as $property) {
             if ($property["name"] === "LAUNCH") {
-                $record->tincanlaunchurl = $CFG->wwwroot."/pluginfile.php/".$context->id."/mod_tincanlaunch/"
-                .$manifestfile->get_filearea()."/".$property["tagData"];
+                // parse_url() wil return the scheme if one exists or null if not
+                // On seriously malformed URLs, parse_url() may return false.
+                if (in_array(parse_url($property["tagData"], PHP_URL_SCHEME), array(null, false), true)) {
+                    $record->tincanlaunchurl = $CFG->wwwroot."/pluginfile.php/".$context->id."/mod_tincanlaunch/"
+                    .$manifestfile->get_filearea()."/".$property["tagData"];
+                } else {
+                    $record->tincanlaunchurl = $property["tagData"];
+                }
             }
         }
     }

--- a/locallib.php
+++ b/locallib.php
@@ -164,7 +164,8 @@ function tincanlaunch_get_launch_url($registrationuuid) {
     }
 
     // Build the URL to be returned.
-    $rtnstring = $tincanlaunch->tincanlaunchurl . "?" . http_build_query(
+    $querySeparator = parse_url($tincanlaunch->tincanlaunchurl, PHP_URL_QUERY) !== null ? '&' : '?';
+    $rtnstring = $tincanlaunch->tincanlaunchurl . $querySeparator . http_build_query(
         array(
             "endpoint" => $url,
             "auth" => "Basic " . $basicauth,


### PR DESCRIPTION
These changes allow the plugin to launch content that is hosted on a remote system and provide a way to implement some kind of authorization via the GET parameters e.g. by signing the launch url.