### PR TITLE
Efficient cron

### DIFF
--- a/tests/check_completion_test.php
+++ b/tests/check_completion_test.php
@@ -1,0 +1,172 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Unit tests for mod_tincanlaunch check_completion task and batch cache.
+ *
+ * @package    mod_tincanlaunch
+ * @copyright  2024 David Pesce <david.pesce@exputo.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace mod_tincanlaunch;
+
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+require_once($CFG->dirroot . '/mod/tincanlaunch/lib.php');
+
+use mod_tincanlaunch\completion\custom_completion;
+
+/**
+ * Unit tests for batch completion cache in custom_completion.
+ *
+ * @package    mod_tincanlaunch
+ * @copyright  2024 David Pesce <david.pesce@exputo.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers \mod_tincanlaunch\completion\custom_completion
+ */
+final class check_completion_test extends \advanced_testcase {
+    /**
+     * Test that get_state uses batch results when set.
+     */
+    public function test_batch_results_cache(): void {
+        $this->resetAfterTest();
+
+        $course = $this->getDataGenerator()->create_course(['enablecompletion' => 1]);
+        $student = $this->getDataGenerator()->create_and_enrol($course, 'student');
+        $student2 = $this->getDataGenerator()->create_and_enrol($course, 'student');
+
+        $instance = $this->getDataGenerator()->create_module('tincanlaunch', [
+            'course' => $course->id,
+            'completion' => COMPLETION_TRACKING_AUTOMATIC,
+            'tincanverbid' => 'http://adlnet.gov/expapi/verbs/completed',
+            'tincanexpiry' => 0,
+        ]);
+
+        $cm = get_coursemodule_from_instance('tincanlaunch', $instance->id);
+        $cminfo = \cm_info::create($cm);
+
+        // Set batch results: student1 completed, student2 not found.
+        custom_completion::set_batch_results([
+            $student->id => true,
+        ]);
+
+        $cc1 = new custom_completion($cminfo, $student->id);
+        $this->assertEquals(COMPLETION_COMPLETE, $cc1->get_state('tincancompletionverb'));
+
+        $cc2 = new custom_completion($cminfo, $student2->id);
+        $this->assertEquals(COMPLETION_INCOMPLETE, $cc2->get_state('tincancompletionverb'));
+
+        // Clean up.
+        custom_completion::set_batch_results(null);
+    }
+
+    /**
+     * Test that get_state falls through to LRS query when batch results are cleared.
+     *
+     * When batch results are null, custom_completion should attempt a per-user
+     * LRS query. We verify this by checking that clearing the cache causes
+     * different code to execute (the TinCanPHP library is invoked).
+     */
+    public function test_batch_results_cleared(): void {
+        $this->resetAfterTest();
+
+        $course = $this->getDataGenerator()->create_course(['enablecompletion' => 1]);
+        $student = $this->getDataGenerator()->create_and_enrol($course, 'student');
+
+        set_config('tincanlaunchlrsendpoint', 'https://lrs.example.com/endpoint/', 'tincanlaunch');
+        set_config('tincanlaunchlrsauthentication', 1, 'tincanlaunch');
+        set_config('tincanlaunchlrslogin', 'key', 'tincanlaunch');
+        set_config('tincanlaunchlrspass', 'secret', 'tincanlaunch');
+        set_config('tincanlaunchlrsduration', 9000, 'tincanlaunch');
+        set_config('tincanlaunchcustomacchp', '', 'tincanlaunch');
+        set_config('tincanlaunchuseactoremail', 1, 'tincanlaunch');
+
+        $instance = $this->getDataGenerator()->create_module('tincanlaunch', [
+            'course' => $course->id,
+            'completion' => COMPLETION_TRACKING_AUTOMATIC,
+            'tincanverbid' => 'http://adlnet.gov/expapi/verbs/completed',
+            'tincanexpiry' => 0,
+        ]);
+
+        $cm = get_coursemodule_from_instance('tincanlaunch', $instance->id);
+        $cminfo = \cm_info::create($cm);
+
+        // First, verify that batch results WORK (cache returns COMPLETE).
+        custom_completion::set_batch_results([$student->id => true]);
+        $cc = new custom_completion($cminfo, $student->id);
+        $this->assertEquals(COMPLETION_COMPLETE, $cc->get_state('tincancompletionverb'));
+
+        // Now clear batch results — the same student should NOT get COMPLETE
+        // because the code will fall through to the per-user LRS path.
+        // The fake LRS will fail, so the result will be INCOMPLETE.
+        custom_completion::set_batch_results(null);
+
+        // Reset the settings cache so tincanlaunch_settings re-reads config.
+        global $tincanlaunchsettings;
+        $tincanlaunchsettings = null;
+
+        // The TinCanPHP library will throw an error when trying to contact
+        // the fake LRS. We catch this to confirm the fallback path ran.
+        // Suppress TinCanPHP deprecation notices (third-party library).
+        $olderror = error_reporting(E_ALL & ~E_DEPRECATED);
+        $cc2 = new custom_completion($cminfo, $student->id);
+        try {
+            $state = $cc2->get_state('tincancompletionverb');
+            // If no exception, the LRS query ran but returned no results.
+            $this->assertEquals(COMPLETION_INCOMPLETE, $state);
+        } catch (\Throwable $e) {
+            // The TinCanPHP library threw an error contacting the fake LRS.
+            // This confirms that clearing batch results causes the fallback
+            // per-user LRS query path to execute.
+            $this->assertStringContainsString('RemoteLRS', $e->getFile());
+        } finally {
+            error_reporting($olderror);
+        }
+    }
+
+    /**
+     * Test that set_batch_results with explicit false marks user incomplete.
+     */
+    public function test_batch_results_explicit_false(): void {
+        $this->resetAfterTest();
+
+        $course = $this->getDataGenerator()->create_course(['enablecompletion' => 1]);
+        $student = $this->getDataGenerator()->create_and_enrol($course, 'student');
+
+        $instance = $this->getDataGenerator()->create_module('tincanlaunch', [
+            'course' => $course->id,
+            'completion' => COMPLETION_TRACKING_AUTOMATIC,
+            'tincanverbid' => 'http://adlnet.gov/expapi/verbs/completed',
+            'tincanexpiry' => 30,
+        ]);
+
+        $cm = get_coursemodule_from_instance('tincanlaunch', $instance->id);
+        $cminfo = \cm_info::create($cm);
+
+        // Set batch results with explicit false (expired).
+        custom_completion::set_batch_results([
+            $student->id => false,
+        ]);
+
+        $cc = new custom_completion($cminfo, $student->id);
+        $this->assertEquals(COMPLETION_INCOMPLETE, $cc->get_state('tincancompletionverb'));
+
+        // Clean up.
+        custom_completion::set_batch_results(null);
+    }
+}

--- a/tests/check_completion_test.php
+++ b/tests/check_completion_test.php
@@ -82,6 +82,7 @@ final class check_completion_test extends \advanced_testcase {
      * LRS query. We verify this by checking that clearing the cache causes
      * different code to execute (the TinCanPHP library is invoked).
      */
+    #[\PHPUnit\Framework\Attributes\IgnoreDeprecations]
     public function test_batch_results_cleared(): void {
         $this->resetAfterTest();
 
@@ -122,8 +123,6 @@ final class check_completion_test extends \advanced_testcase {
 
         // The TinCanPHP library will throw an error when trying to contact
         // the fake LRS. We catch this to confirm the fallback path ran.
-        // Suppress TinCanPHP deprecation notices (third-party library).
-        $olderror = error_reporting(E_ALL & ~E_DEPRECATED);
         $cc2 = new custom_completion($cminfo, $student->id);
         try {
             $state = $cc2->get_state('tincancompletionverb');
@@ -134,8 +133,6 @@ final class check_completion_test extends \advanced_testcase {
             // This confirms that clearing batch results causes the fallback
             // per-user LRS query path to execute.
             $this->assertStringContainsString('RemoteLRS', $e->getFile());
-        } finally {
-            error_reporting($olderror);
         }
     }
 

--- a/tests/lib_test.php
+++ b/tests/lib_test.php
@@ -537,4 +537,155 @@ final class lib_test extends \advanced_testcase {
         $this->assertIsArray($result);
         $this->assertEmpty($result);
     }
+
+    /**
+     * Test tincanlaunch_build_actor_map with email (mbox) identification.
+     */
+    public function test_build_actor_map_email(): void {
+        $settings = [
+            'tincanlaunchcustomacchp' => '',
+            'tincanlaunchuseactoremail' => 1,
+        ];
+
+        $user1 = (object) ['id' => 10, 'idnumber' => '', 'email' => 'alice@example.com', 'username' => 'alice'];
+        $user2 = (object) ['id' => 20, 'idnumber' => '', 'email' => 'bob@example.com', 'username' => 'bob'];
+
+        $map = tincanlaunch_build_actor_map([$user1, $user2], $settings);
+
+        $this->assertArrayHasKey('mailto:alice@example.com', $map);
+        $this->assertEquals(10, $map['mailto:alice@example.com']);
+        $this->assertArrayHasKey('mailto:bob@example.com', $map);
+        $this->assertEquals(20, $map['mailto:bob@example.com']);
+    }
+
+    /**
+     * Test tincanlaunch_build_actor_map with custom account homepage (idnumber).
+     */
+    public function test_build_actor_map_account(): void {
+        $settings = [
+            'tincanlaunchcustomacchp' => 'https://myinstitution.example.com',
+            'tincanlaunchuseactoremail' => 1,
+        ];
+
+        $user1 = (object) ['id' => 10, 'idnumber' => 'STU001', 'email' => 'alice@example.com', 'username' => 'alice'];
+        $user2 = (object) ['id' => 20, 'idnumber' => 'STU002', 'email' => 'bob@example.com', 'username' => 'bob'];
+
+        $map = tincanlaunch_build_actor_map([$user1, $user2], $settings);
+
+        $this->assertArrayHasKey('https://myinstitution.example.com|STU001', $map);
+        $this->assertEquals(10, $map['https://myinstitution.example.com|STU001']);
+        $this->assertArrayHasKey('https://myinstitution.example.com|STU002', $map);
+        $this->assertEquals(20, $map['https://myinstitution.example.com|STU002']);
+    }
+
+    /**
+     * Test tincanlaunch_build_actor_map fallback to wwwroot + username.
+     */
+    public function test_build_actor_map_fallback(): void {
+        global $CFG;
+
+        $settings = [
+            'tincanlaunchcustomacchp' => '',
+            'tincanlaunchuseactoremail' => 0,
+        ];
+
+        $user1 = (object) ['id' => 10, 'idnumber' => '', 'email' => '', 'username' => 'alice'];
+
+        $map = tincanlaunch_build_actor_map([$user1], $settings);
+
+        $expectedkey = $CFG->wwwroot . '|alice';
+        $this->assertArrayHasKey($expectedkey, $map);
+        $this->assertEquals(10, $map[$expectedkey]);
+    }
+
+    /**
+     * Test tincanlaunch_build_actor_map with mixed identification strategies.
+     */
+    public function test_build_actor_map_mixed(): void {
+        $settings = [
+            'tincanlaunchcustomacchp' => 'https://myinstitution.example.com',
+            'tincanlaunchuseactoremail' => 1,
+        ];
+
+        // User1 has idnumber — should use account-based.
+        $user1 = (object) ['id' => 10, 'idnumber' => 'STU001', 'email' => 'alice@example.com', 'username' => 'alice'];
+        // User2 has no idnumber but has email — should use mbox.
+        $user2 = (object) ['id' => 20, 'idnumber' => '', 'email' => 'bob@example.com', 'username' => 'bob'];
+
+        $map = tincanlaunch_build_actor_map([$user1, $user2], $settings);
+
+        $this->assertArrayHasKey('https://myinstitution.example.com|STU001', $map);
+        $this->assertEquals(10, $map['https://myinstitution.example.com|STU001']);
+        $this->assertArrayHasKey('mailto:bob@example.com', $map);
+        $this->assertEquals(20, $map['mailto:bob@example.com']);
+    }
+
+    /**
+     * Test tincanlaunch_match_statement_to_user with mbox actor.
+     */
+    public function test_match_statement_to_user_mbox(): void {
+        $actormap = ['mailto:alice@example.com' => 10, 'mailto:bob@example.com' => 20];
+
+        // Suppress TinCanPHP deprecation notices (third-party library).
+        $olderror = error_reporting(E_ALL & ~E_DEPRECATED);
+        $statement = new \TinCan\Statement([
+            'actor' => [
+                'mbox' => 'mailto:alice@example.com',
+                'objectType' => 'Agent',
+            ],
+            'verb' => ['id' => 'http://adlnet.gov/expapi/verbs/completed'],
+            'object' => ['id' => 'https://example.com/activity', 'objectType' => 'Activity'],
+        ]);
+
+        $result = tincanlaunch_match_statement_to_user($statement, $actormap);
+        error_reporting($olderror);
+        $this->assertEquals(10, $result);
+    }
+
+    /**
+     * Test tincanlaunch_match_statement_to_user with account actor.
+     */
+    public function test_match_statement_to_user_account(): void {
+        $actormap = ['https://myinstitution.example.com|STU001' => 10];
+
+        // Suppress TinCanPHP deprecation notices (third-party library).
+        $olderror = error_reporting(E_ALL & ~E_DEPRECATED);
+        $statement = new \TinCan\Statement([
+            'actor' => [
+                'account' => [
+                    'homePage' => 'https://myinstitution.example.com',
+                    'name' => 'STU001',
+                ],
+                'objectType' => 'Agent',
+            ],
+            'verb' => ['id' => 'http://adlnet.gov/expapi/verbs/completed'],
+            'object' => ['id' => 'https://example.com/activity', 'objectType' => 'Activity'],
+        ]);
+
+        $result = tincanlaunch_match_statement_to_user($statement, $actormap);
+        error_reporting($olderror);
+        $this->assertEquals(10, $result);
+    }
+
+    /**
+     * Test tincanlaunch_match_statement_to_user returns null for unknown actor.
+     */
+    public function test_match_statement_to_user_unknown(): void {
+        $actormap = ['mailto:alice@example.com' => 10];
+
+        // Suppress TinCanPHP deprecation notices (third-party library).
+        $olderror = error_reporting(E_ALL & ~E_DEPRECATED);
+        $statement = new \TinCan\Statement([
+            'actor' => [
+                'mbox' => 'mailto:unknown@example.com',
+                'objectType' => 'Agent',
+            ],
+            'verb' => ['id' => 'http://adlnet.gov/expapi/verbs/completed'],
+            'object' => ['id' => 'https://example.com/activity', 'objectType' => 'Activity'],
+        ]);
+
+        $result = tincanlaunch_match_statement_to_user($statement, $actormap);
+        error_reporting($olderror);
+        $this->assertNull($result);
+    }
 }

--- a/tests/lib_test.php
+++ b/tests/lib_test.php
@@ -623,11 +623,10 @@ final class lib_test extends \advanced_testcase {
     /**
      * Test tincanlaunch_match_statement_to_user with mbox actor.
      */
+    #[\PHPUnit\Framework\Attributes\IgnoreDeprecations]
     public function test_match_statement_to_user_mbox(): void {
         $actormap = ['mailto:alice@example.com' => 10, 'mailto:bob@example.com' => 20];
 
-        // Suppress TinCanPHP deprecation notices (third-party library).
-        $olderror = error_reporting(E_ALL & ~E_DEPRECATED);
         $statement = new \TinCan\Statement([
             'actor' => [
                 'mbox' => 'mailto:alice@example.com',
@@ -638,18 +637,16 @@ final class lib_test extends \advanced_testcase {
         ]);
 
         $result = tincanlaunch_match_statement_to_user($statement, $actormap);
-        error_reporting($olderror);
         $this->assertEquals(10, $result);
     }
 
     /**
      * Test tincanlaunch_match_statement_to_user with account actor.
      */
+    #[\PHPUnit\Framework\Attributes\IgnoreDeprecations]
     public function test_match_statement_to_user_account(): void {
         $actormap = ['https://myinstitution.example.com|STU001' => 10];
 
-        // Suppress TinCanPHP deprecation notices (third-party library).
-        $olderror = error_reporting(E_ALL & ~E_DEPRECATED);
         $statement = new \TinCan\Statement([
             'actor' => [
                 'account' => [
@@ -663,18 +660,16 @@ final class lib_test extends \advanced_testcase {
         ]);
 
         $result = tincanlaunch_match_statement_to_user($statement, $actormap);
-        error_reporting($olderror);
         $this->assertEquals(10, $result);
     }
 
     /**
      * Test tincanlaunch_match_statement_to_user returns null for unknown actor.
      */
+    #[\PHPUnit\Framework\Attributes\IgnoreDeprecations]
     public function test_match_statement_to_user_unknown(): void {
         $actormap = ['mailto:alice@example.com' => 10];
 
-        // Suppress TinCanPHP deprecation notices (third-party library).
-        $olderror = error_reporting(E_ALL & ~E_DEPRECATED);
         $statement = new \TinCan\Statement([
             'actor' => [
                 'mbox' => 'mailto:unknown@example.com',
@@ -685,7 +680,6 @@ final class lib_test extends \advanced_testcase {
         ]);
 
         $result = tincanlaunch_match_statement_to_user($statement, $actormap);
-        error_reporting($olderror);
         $this->assertNull($result);
     }
 }


### PR DESCRIPTION
One LRS request per module instead of per user. Remove the agent filter from the xAPI query so it returns statements for ALL users for a given activity + verb. Then reverse-map each statement's actor back to a Moodle user. Track the last successful run time and pass it as since on subsequent runs.

Use a static batch cache in custom_completion so that when the cron calls $completion->update_state() (which internally calls custom_completion->get_state()), it hits the pre-populated cache instead of making another LRS request. On-demand checks (completion_check.php) bypass the cache and still query the LRS per-user.