### PR TITLE
implement grading feature and associated tests

### DIFF
--- a/backup/moodle2/backup_tincanlaunch_stepslib.php
+++ b/backup/moodle2/backup_tincanlaunch_stepslib.php
@@ -41,7 +41,7 @@ class backup_tincanlaunch_activity_structure_step extends backup_activity_struct
         $tincanlaunch = new backup_nested_element('tincanlaunch', ['id'], [
             'name', 'intro', 'introformat', 'tincanlaunchurl', 'tincanactivityid',
             'tincanverbid', 'tincanexpiry', 'overridedefaults', 'tincanlaunchtype',
-            'tincanmultipleregs', 'tincansimplelaunchnav', 'timecreated', 'timemodified']);
+            'tincanmultipleregs', 'tincansimplelaunchnav', 'grade', 'timecreated', 'timemodified']);
 
         $tincanlaunchlrs = new backup_nested_element(
             'tincanlaunchlrs',

--- a/backup/moodle2/restore_tincanlaunch_stepslib.php
+++ b/backup/moodle2/restore_tincanlaunch_stepslib.php
@@ -82,9 +82,18 @@ class restore_tincanlaunch_activity_structure_step extends restore_activity_stru
      *
      */
     protected function after_execute() {
+        global $DB;
+
         // Add tincanlaunch related files.
         $this->add_related_files('mod_tincanlaunch', 'intro', null);
         $this->add_related_files('mod_tincanlaunch', 'package', null);
         $this->add_related_files('mod_tincanlaunch', 'content', null);
+
+        // Recreate the grade item if the activity has grading enabled.
+        $activityid = $this->task->get_activityid();
+        $tincanlaunch = $DB->get_record('tincanlaunch', ['id' => $activityid]);
+        if ($tincanlaunch) {
+            tincanlaunch_grade_item_update($tincanlaunch);
+        }
     }
 }

--- a/db/install.xml
+++ b/db/install.xml
@@ -19,6 +19,7 @@
         <FIELD NAME="tincanmultipleregs" TYPE="int" LENGTH="1" NOTNULL="true" SEQUENCE="false" DEFAULT="1"/>
         <FIELD NAME="tincanlaunchtype" TYPE="int" LENGTH="1" NOTNULL="true" SEQUENCE="false" DEFAULT="1" COMMENT="Content type: 0 = Zip package, 1 = External URL"/>
         <FIELD NAME="tincansimplelaunchnav" TYPE="int" LENGTH="1" NOTNULL="true" SEQUENCE="false" DEFAULT="0"/>
+        <FIELD NAME="grade" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" DEFAULT="0" COMMENT="Maximum grade (0 = no gradebook item)"/>
         <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
         <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
       </FIELDS>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -117,6 +117,26 @@ function xmldb_tincanlaunch_upgrade($oldversion) {
         upgrade_mod_savepoint(true, 2026022501, 'tincanlaunch');
     }
 
+    if ($oldversion < 2026022502) {
+        $table = new xmldb_table('tincanlaunch');
+        $field = new xmldb_field(
+            'grade',
+            XMLDB_TYPE_INTEGER,
+            '10',
+            null,
+            XMLDB_NOTNULL,
+            null,
+            0,
+            'tincansimplelaunchnav'
+        );
+
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        upgrade_mod_savepoint(true, 2026022502, 'tincanlaunch');
+    }
+
     // Final return of upgrade result (true, all went good) to Moodle.
     return true;
 }

--- a/grade.php
+++ b/grade.php
@@ -15,21 +15,20 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Defines the version of tincanlaunch
- *
- * This code fragment is called by moodle_needs_upgrading() and
- * /admin/index.php
+ * Redirect the user to the activity view when clicking a grade in the gradebook.
  *
  * @package    mod_tincanlaunch
  * @copyright  2013 Andrew Downes
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die();
+require_once('../../config.php');
 
-$plugin->version   = 2026022502;      // The current module version (Date: YYYYMMDDXX).
-$plugin->requires  = 2024100700;      // Requires Moodle 4.5.
-$plugin->supported = [405, 501];      // Supported Moodle versions.
-$plugin->component = 'mod_tincanlaunch'; // To check on upgrade, that module sits in correct place.
-$plugin->maturity  = MATURITY_ALPHA;
-$plugin->release   = 'v2.0.0-alpha';
+$id = required_param('id', PARAM_INT);
+
+$cm = get_coursemodule_from_instance('tincanlaunch', $id, 0, false, MUST_EXIST);
+$course = get_course($cm->course);
+
+require_login($course, false, $cm);
+
+redirect(new moodle_url('/mod/tincanlaunch/view.php', ['id' => $cm->id]));

--- a/lang/en/tincanlaunch.php
+++ b/lang/en/tincanlaunch.php
@@ -48,6 +48,7 @@ $string['errorlaunchurlempty'] = 'Launch URL is required when content type is Ex
 $string['eventactivitycompleted'] = 'Activity completed';
 $string['eventactivitylaunched'] = 'Activity launched';
 $string['expirecredentials'] = 'Expire credentials';
+$string['grade_help'] = 'Grades are derived from the xAPI result.score.scaled value on the completion verb statement. The highest score per user is used.';
 $string['idmissing'] = 'You must specify a course_module ID or an instance ID';
 $string['lrsdefaults'] = 'LRS Default Settings';
 $string['lrsheading'] = 'Override default LRS settings';

--- a/mod_form.php
+++ b/mod_form.php
@@ -208,6 +208,9 @@ class mod_tincanlaunch_mod_form extends moodleform_mod {
         $mform->hideIf('tincanmultipleregs', 'tincansimplelaunchnav', 'checked');
         $mform->addHelpButton('tincanmultipleregs', 'tincanmultipleregs', 'tincanlaunch');
 
+        // Grade settings.
+        $this->standard_grading_coursemodule_elements();
+
         // Add standard elements, common to all modules.
         $this->standard_coursemodule_elements();
         // Add standard buttons, common to all modules.

--- a/tests/generator/lib.php
+++ b/tests/generator/lib.php
@@ -49,6 +49,7 @@ class mod_tincanlaunch_generator extends testing_module_generator {
             'tincanmultipleregs' => 1,
             'tincanlaunchtype' => 1,
             'tincansimplelaunchnav' => 0,
+            'grade' => 0,
             'tincanlaunchlrsendpoint' => 'https://lrs.example.com/endpoint/',
             'tincanlaunchlrsauthentication' => 1,
             'tincanlaunchlrslogin' => 'testkey',


### PR DESCRIPTION
Teachers can now set a maximum grade (e.g., 100) on any xAPI Launch Link activity. When the scheduled cron task runs, it extracts scores from xAPI statements already being fetched from the LRS and pushes them into Moodle's gradebook automatically. If a teacher sets the grade to "None" (0), the activity behaves exactly as before — no gradebook item is created.

How Grades Flow
- LRS → cron (check_completion task) → extract result.score.scaled → Moodle gradebook

The key design decision was zero additional LRS requests. The existing check_completion cron task already fetches full xAPI statements (with result.score.scaled included) for completion tracking. Grade sync piggybacks on that same batch of statements. After the completion loop finishes, a second pass over the same statements extracts scores when grade > 0.

  Scoring Logic
  - xAPI result.score.scaled is a value between -1.0 and 1.0
  - Negative scores are clamped to 0 (some LRS content uses negatives)
  - The highest scaled score per user wins (across all matching statements)
  - Raw grade = scaled * max_grade (e.g., 0.85 × 100 = 85)